### PR TITLE
NOTICK: Also publish the CPK's "companion" POM to Maven Central.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,13 +71,13 @@ subprojects {
             ]
         }
     }
-}
 
-tasks.register('compileAll') { task ->
-    description = "Compiles all the Kotlin and Java classes, including all of the test classes."
-    group = "verification"
+    tasks.register('compileAll') { task ->
+        description = "Compiles all the Kotlin and Java classes, including all of the test classes."
+        group = "verification"
 
-    task.dependsOn tasks.withType(AbstractCompile)
+        task.dependsOn tasks.withType(AbstractCompile)
+    }
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,8 @@ group=com.r3.corda.lib.ci
 version=0.1
 kotlin.incremental=false
 
+kotlin.stdlib.default.dependency=false
+
 # License
 licenseName=Apache License, Version 2.0
 licenseUrl=https://www.apache.org/licenses/LICENSE-2.0
@@ -16,7 +18,7 @@ internalPublishVersion = 0.1.1626799016907-beta
 confidential_id_release_group=com.r3.corda.lib.ci
 confidential_id_release_version=2.0-DevPreview
 
-corda_gradle_plugins_version=6.0.0-DevPreview-RC04
+corda_gradle_plugins_version=6.0.0-DevPreview-RC07
 kotlin_version=1.4.21
 junit_version=5.7.2
 slf4j_version=1.7.30

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,3 +1,4 @@
 # Artifacts have to be included/excluded by their artifact config name
 #   these do not always line up with the location in the git repo
 ci-workflows
+ci-workflows/ci-workflows.corda.cpk


### PR DESCRIPTION
The `cordapp-cpk` also publishes an extra POM artifact, with these Maven coordinates:
```xml
<dependency>
    <groupId>com.r3.corda.lib.ci.ci-workflows</groupId>
    <artifactId>ci-workflows.corda.cpk</artifactId>
    <version>${version}</version>
    <type>pom</type>
</dependency>
```
This POM must also be published to Maven Central, and must therefore be added to the Jenkins pipeline's `whitelist.txt` file.

You must also publish this CPK using `cordapp-cpk-6.0.0-DevPreview-RC05` or later to ensure that this "companion" POM contains everything that Maven Central needs.

The `compileAll` task also needs to be defined for every `subproject` in order to be effective :wink:.