### PR TITLE
NOTICK: Generate KDocs using Dokka.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id 'net.corda.cordapp.cordapp-configuration'
     id 'org.jetbrains.kotlin.jvm' apply false
+    id 'org.jetbrains.dokka' apply false
     id 'io.gitlab.arturbosch.detekt'
     id 'com.jfrog.artifactory'
     id 'jacoco'
@@ -88,6 +89,8 @@ configure(publishProjects) { subproject ->
     apply plugin: 'com.jfrog.artifactory'
 
     pluginManager.withPlugin('java-library') {
+        apply plugin: 'org.jetbrains.dokka'
+
         tasks.register('sourceJar', Jar) {
             dependsOn subproject.classes
             archiveClassifier = 'sources'
@@ -95,9 +98,12 @@ configure(publishProjects) { subproject ->
         }
 
         tasks.register('javadocJar', Jar) {
-            dependsOn subproject.javadoc
+            description = 'Create JavaDoc Jar from Dokka docs'
+            group = 'documentation'
+
+            def dokkaHtml = tasks.named('dokkaHtml', org.jetbrains.dokka.gradle.DokkaTask)
+            from dokkaHtml.flatMap { it.outputDirectory }
             archiveClassifier = 'javadoc'
-            from javadoc.destinationDir
         }
 
         tasks.withType(Jar).matching { !(it.name ==~ /cp[bk]/) }.configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ confidential_id_release_version=2.0-DevPreview
 
 corda_gradle_plugins_version=6.0.0-DevPreview-RC07
 kotlin_version=1.4.21
+dokka_version=1.4.32
 junit_version=5.7.2
 slf4j_version=1.7.30
 log4j_version=2.11.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,7 @@ pluginManagement {
         id 'org.jetbrains.kotlin.jvm' version kotlin_version
         id 'org.jetbrains.kotlin.plugin.noarg' version kotlin_version
         id 'org.jetbrains.kotlin.plugin.allopen' version kotlin_version
+        id 'org.jetbrains.dokka' version dokka_version
         id 'com.jfrog.artifactory' version jfrogArtifactoryPluginVersion
         id 'io.gitlab.arturbosch.detekt' version detektVersion
         id 'com.r3.internal.gradle.plugins.r3ArtifactoryPublish' version internalPublishVersion


### PR DESCRIPTION
Generate KDocs instead of JavaDocs for published modules.