### PR TITLE
NOTICK: Ensure sources and javadoc jars have same base name as main jar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,10 @@ configure(publishProjects) { subproject ->
     pluginManager.withPlugin('java-library') {
         apply plugin: 'org.jetbrains.dokka'
 
+        def jarTask = tasks.named('jar', Jar)
         tasks.register('sourceJar', Jar) {
             dependsOn subproject.classes
+            archiveBaseName = jarTask.flatMap { it.archiveBaseName }
             archiveClassifier = 'sources'
             from sourceSets.main.allSource
         }
@@ -103,6 +105,7 @@ configure(publishProjects) { subproject ->
 
             def dokkaHtml = tasks.named('dokkaHtml', org.jetbrains.dokka.gradle.DokkaTask)
             from dokkaHtml.flatMap { it.outputDirectory }
+            archiveBaseName = jarTask.flatMap { it.archiveBaseName }
             archiveClassifier = 'javadoc'
         }
 


### PR DESCRIPTION
The `-sources` and `-javadoc` jars are inexplicably named correctly already, but assign their names correctly anyway!