### PR TITLE
NOTICK: Remove unused Maven repositories.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,7 @@ subprojects {
     group confidential_id_release_group
 
     repositories {
-        mavenLocal()
         mavenCentral()
-        maven { url "$artifactoryContextUrl/corda-lib" }
-        maven { url "$artifactoryContextUrl/corda-lib-dev" }
-        maven { url "$artifactoryContextUrl/corda-releases" }
         maven { url "$artifactoryContextUrl/corda-dependencies" }
         //needed for C5 binaries
         maven {


### PR DESCRIPTION
Remove Maven repositories that are no longer used to build Confidential Identities.