### PR TITLE
NOTICK: Update the internal publish plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,7 @@ artifactoryContextUrl=https://software.r3.com/artifactory
 
 corda_release_group=net.corda
 corda_release_version=5.0.0-DevPreview-1.0
-internalPublishVersion = 0.1.1626799016907-beta
-
+internalPublishVersion = 1.0.0
 confidential_id_release_group=com.r3.corda.lib.ci
 confidential_id_release_version=2.0.0-DevPreview
 


### PR DESCRIPTION
start using released versions (first one is 1.0.0)