### PR TITLE
ENT-6267 Add check to block signature verification bypass

### DIFF
--- a/workflows/src/main/kotlin/com/r3/corda/lib/ci/services/SignedKeyServiceImpl.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/ci/services/SignedKeyServiceImpl.kt
@@ -79,5 +79,9 @@ class SignedKeyServiceImpl : SignedKeyService {
                 ex
             )
         }
+        if (signedKeyForAccount.signedChallengeResponse.sig.by != signedKeyForAccount.publicKey) {
+            throw SignatureException("The public key used to sign the challenge response is not the same key " +
+                    "returned as part of the SignedKeyForAccount")
+        }
     }
 }

--- a/workflows/src/test/kotlin/com/r3/corda/lib/ci/services/SignedKeyServiceImplTest.kt
+++ b/workflows/src/test/kotlin/com/r3/corda/lib/ci/services/SignedKeyServiceImplTest.kt
@@ -1,0 +1,73 @@
+package com.r3.corda.lib.ci.services
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.r3.corda.lib.ci.workflows.ChallengeResponse
+import com.r3.corda.lib.ci.workflows.SignedKeyForAccount
+import net.corda.v5.application.crypto.SignedData
+import net.corda.v5.base.types.OpaqueBytes
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.serialization.SerializedBytes
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.security.PublicKey
+import java.security.SignatureException
+
+class SignedKeyServiceImplTest {
+
+    private lateinit var signedKeyService: SignedKeyService
+
+    @BeforeEach
+    fun setUp() {
+        signedKeyService = SignedKeyServiceImpl().apply {
+            signatureVerifier = mock()
+            hashingService = mock {
+                on { hash(any<OpaqueBytes>()) } doReturn SecureHash.create("SHA-256:0123456789ABCDEF")
+            }
+        }
+    }
+
+    @Test
+    fun `PublicKey for SignedKeyForAccount must match the PublicKey used to sign the included data`() {
+        fun mockSignedKeyForAccount(key: PublicKey, signingKey: PublicKey): SignedKeyForAccount {
+            val signature = mock<DigitalSignature.WithKey> {
+                on { by } doReturn signingKey
+            }
+            val signedData = mock<SignedData<ChallengeResponse>> {
+                on { sig } doReturn signature
+                on { raw } doReturn mock<SerializedBytes<ChallengeResponse>>()
+            }
+            return mock {
+                on { publicKey } doReturn key
+                on { signedChallengeResponse } doReturn signedData
+            }
+        }
+
+
+        fun callFunctionUnderTest(key: PublicKey, signingKey: PublicKey) =
+            signedKeyService.verifySignedChallengeResponseSignature(
+                mockSignedKeyForAccount(key, signingKey)
+            )
+
+
+        // Mock two different keys for testing
+        val key1: PublicKey = mock()
+        val key2: PublicKey = mock()
+
+        // If the key that signed the challenge response data is different to the key returned in the
+        // SignedKeyForAccount then no exception should be thrown.
+        assertThrows<SignatureException> {
+            callFunctionUnderTest(key1, key2)
+        }
+
+        // If the key that signed the challenge response data is the same as the key returned in the
+        // SignedKeyForAccount then no exception should be thrown.
+        assertDoesNotThrow {
+            callFunctionUnderTest(key1, key1)
+        }
+    }
+}


### PR DESCRIPTION
Previously `RequestForKnownKey` was updated the verify that the key returned by the counter party which we store mapped to that party was the same as the key we sent to the counter party for an ownership claim (see https://github.com/corda/corda5-confidential-identities/pull/24). This does not protect against the signature verification bypass which was originally reported however because the signature verification is done using another key. This PR verifies that the key returned as part of `SignedKeyForAccount` is the same as the key used to verify the signature on the returned challenge response. This check along with the previous check added will verify that the counter-party signed the challenge response with the same key that we requested the ownership claim for.